### PR TITLE
Update webView protocol to open external links in web browser

### DIFF
--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -147,8 +147,19 @@ extension AdaWebHost {
 }
 
 extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        print("Error loading")
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void) {
+        if navigationAction.navigationType == WKNavigationType.linkActivated {
+            if let url = navigationAction.request.url {
+                let shared = UIApplication.shared
+                if shared.canOpenURL(url) {
+                    shared.open(url, options: [:], completionHandler: nil)
+                }
+            }
+            decisionHandler(.cancel)
+        }
+        else {
+            decisionHandler(.allow)
+        }
     }
 }
 


### PR DESCRIPTION
**Problem**
Links inside the webview that opened into new window (with `target="_blank"`) were not working. You can reproduce the problem by typing "link" in the ExampleApp.

**Solution**
Open links into a new browser window. (Unless there is a better way?)
https://stackoverflow.com/questions/30603671/open-a-wkwebview-target-blank-link-in-safari/50924004#50924004